### PR TITLE
Add SwarmVault to Context Engineering and SwarmClaw to Autonomous Software Engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ AI agents designed to work as fully autonomous "junior developers" - they plan, 
 - [Agentless](https://github.com/OpenAutoCoder/Agentless) - Simpler, agentless approach to solving coding tasks - no complex agent scaffolding needed. **[Free]** **[Open Source]**
 - [Cosine Genie](https://cosine.sh) - AI software engineer trained on real-world codebases. Understands complex repos and makes changes autonomously. **[Paid]**
 - [Factory AI](https://www.factory.ai) - Enterprise autonomous coding platform. Droids that handle refactoring, migrations, and code modernization. **[Enterprise]**
+- [SwarmClaw](https://github.com/swarmclawai/swarmclaw) - Self-hosted multi-agent runtime that delegates to Claude Code, Codex, Gemini CLI, OpenCode, Copilot CLI, Cursor Agent, Goose, Qwen Code, and Droid. Org chart view, schedules, runtime skills, persistent memory, sub-agent spawning, MCP-native. Electron desktop app, CLI, and Docker. **[Free]** **[Open Source]**
 ## AI App Builders (No-Code)
 
 Platforms where you describe an app in plain English and get a working, deployable application - the purest form of vibe coding. **No coding knowledge needed.**
@@ -417,6 +418,7 @@ The emerging discipline of feeding AI the right context to improve output qualit
 - [Codetex](https://codetex.io) - Convert your code into context-optimized formats for AI consumption. **[Free]**
 - [llms.txt Standard](https://llmstxt.org) - Proposed standard for websites to provide LLM-friendly versions of their content (like robots.txt but for AI). **[Specification]**
 - [CONTRIBUTING.md / CLAUDE.md patterns](https://docs.anthropic.com/en/docs/claude-code/memory) - Using project documentation files to give AI agents architectural context, coding standards, and project-specific instructions.
+- [SwarmVault](https://github.com/swarmclawai/swarmvault) - Local-first RAG knowledge vault. Compiles raw sources (books, notes, transcripts, exports, docs, code) into a durable markdown wiki with a knowledge graph and a hybrid SQLite FTS plus embeddings index. Built-in MCP server (`npx -y @swarmvaultai/cli mcp`) lets Claude Code, Codex, OpenCode, and any MCP client retrieve compact wiki summaries instead of repeatedly re-reading raw files - direct token savings on long sessions. **[Free]** **[Open Source]**
 ## MCP Servers for Coding
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard by Anthropic that lets AI agents securely connect to tools, databases, and services. Think of it as "plugins for AI."


### PR DESCRIPTION
Adds two community resources.

### SwarmVault (Context Engineering)

[SwarmVault](https://github.com/swarmclawai/swarmvault) is a local-first RAG knowledge vault. It compiles raw sources (books, notes, transcripts, exports, docs, code) into a durable markdown wiki with a knowledge graph and a hybrid SQLite FTS plus embeddings index.

Direct fit for the Context Engineering section: in long sessions, agents like Claude Code and Codex burn tokens re-reading source files. SwarmVault compiles those sources into compact wiki pages once, then the bundled MCP server (`npx -y @swarmvaultai/cli mcp`) hands the agent only the relevant chunks via page search and query tools. Practical token savings come from replacing repeated full-file reads with targeted retrieval. MIT.

### SwarmClaw (Autonomous Software Engineers)

[SwarmClaw](https://github.com/swarmclawai/swarmclaw) is a self-hosted multi-agent runtime that delegates to Claude Code, Codex, Gemini CLI, OpenCode, Copilot CLI, Cursor Agent, Goose, Qwen Code, and Droid as first-class coding agents. Features include an org chart view, schedules, runtime skills, persistent memory, sub-agent spawning, and reviewed conversation-to-skill learning. MCP-native (server and client). Ships as an Electron desktop app, CLI, and Docker image. MIT.