### PR TITLE
Add vibeprompt to Prompt Engineering → Guides & Techniques

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ How to write better prompts that produce better AI-generated code.
 - [Learn Prompting](https://learnprompting.org) - Free, open-source guide to prompt engineering. Covers basics to advanced techniques.
 - [Cursor Prompting Tips](https://docs.cursor.com/guides) - Cursor's official guide to getting the best results from Composer, Tab, and Chat.
 - [Vibe Coding Academy](https://vibecodingacademy.ai) - Dedicated learning platform for vibe coding techniques and AI-assisted development workflows.
+- [vibeprompt](https://vibeprompt.tech) - Free 10-step vibe coding workflow with 56 copy-paste prompts, 17 deep-dive articles, 46 field-tested fixes for common AI-coding failures, and an interactive AGENTS.md + PRD generator. Open source, MIT.
 ### Prompt Libraries & Templates
 
 Pre-built prompts optimized for common coding tasks.


### PR DESCRIPTION
Adds [vibeprompt](https://vibeprompt.tech) to **Prompt Engineering for Code → Guides & Techniques**, next to Vibe Coding Academy.

**What it is:** a free, MIT-licensed methodology resource for shipping with AI:
- 10-step workflow (Idea → Plan → Build → Test → Ship → Launch → Iterate)
- 56 copy-paste prompts mapped to each step
- 17 deep-dive articles
- 46 named recipes for common AI-coding failures
- Interactive AGENTS.md + PRD generator (works with Claude Code, Cursor, Codex, Windsurf, etc.)

**Why this section:** "Guides & Techniques" is about how to write better prompts that produce better AI-generated code. vibeprompt is exactly that — a methodology + prompt library, not a tool or agent.

I personally maintain it. Happy to revise wording, move to a different section, or drop entirely if it doesn't fit. Thanks for maintaining the list! 🙏