### PR TITLE
Add VibeKit to AI App Builders (No-Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Platforms where you describe an app in plain English and get a working, deployab
 - [Buzzy](https://www.buzzy.buzz) - Turn Figma designs into working apps with AI. Design-first approach to app building. **[Freemium]**
 - [Pico](https://picoapps.xyz) - Build micro-apps with a single prompt. Fast, simple, shareable web apps in seconds. **[Free]**
 - [Literally Anything](https://www.literallyanything.io) - Type anything → get a working web app. The simplest possible vibe coding interface. **[Freemium]**
+- [VibeKit](https://apps.apple.com/us/app/vibekit-agent-devops/id6760206636) - Each app gets its own persistent AI coding agent that builds, hosts, and keeps improving it — with a GitHub repo, database, and live domain. Driven from your phone (native iOS), Telegram, or CLI. **[Freemium]**
 ## AI Code Completion & Assistants
 
 Inline code suggestions, autocomplete, and chat-based coding assistants - the broadest category of AI coding tools.


### PR DESCRIPTION
Adds **VibeKit** (https://vibekit.bot) to the **AI App Builders (No-Code)** section.

Most builders on the list are web/laptop-first. VibeKit's angle is mobile: each app gets its own persistent AI coding agent that builds, hosts, and keeps improving it over time — with a GitHub repo, a database, and a live domain included — driven from your phone (native iOS), Telegram, or CLI. BYOK for Claude/OpenAI or pay-as-you-go.

Matched the section's entry format and pricing tag. Disclosure: I am the maker — happy to tweak wording/placement. Thanks for maintaining this list!
