### PR TITLE
Add Tura to Terminal / CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ AI agents that operate from your terminal, reading, writing, and executing code 
 - [Plandex](https://github.com/plandex-ai/plandex) - Terminal-based AI coding agent designed for complex, multi-file tasks with built-in version control for AI changes. **[Free]** **[Open Source]**
 - [Amp](https://amp.dev) - AI coding agent from Sourcegraph. Terminal and IDE modes with deep code intelligence integration. **[Free Tier Available]**
 - [Blackbox AI](https://www.blackbox.ai) - Multi-model AI coding agent that uses a "Chairman" architecture - sends tasks to multiple models in parallel and picks the best result. **[Freemium]**
+- [Tura](https://github.com/Tura-AI/tura) - Open-source local coding agent with CLI/TUI/GUI, task-scoped context, macro command execution, verification, and public benchmark artifacts. **[Free]** **[Open Source]**
 ### Browser-Based
 
 Full development environments that run in your browser - no local setup required.


### PR DESCRIPTION
Hi! I maintain Tura, an actively maintained AGPL-3.0 local coding agent for AI-assisted software development. It provides CLI, TUI, and GUI entry points, edits repositories, runs commands, verifies changes, and publishes benchmark methodology and results.

This PR adds one concise entry at the end of Terminal / CLI. The project is free and open source, the link points to the public repository, and the description follows the contribution format without making superlative claims.

Repository: https://github.com/Tura-AI/tura
Benchmark: https://turaai.net/benchmark

Thanks for considering it.