### PR TITLE
Add UIZZE to MCP design resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ From the official MCP repository maintained by Anthropic.
 ### Design
 
 - [Figma MCP Server](https://github.com/nicobailon-figma/figma-mcp) - Inspect Figma designs: layout, tokens, components, variants. Bridges the design-to-code gap.
+- [UIZZE](https://uizze.com) - UI reference research for coding agents: a free skill for design contracts and finish-gate reviews, plus MCP access to real web and iOS screens. **[Free Skill]**
 ### Search
 
 - [Brave Search MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search) - Web search via Brave's API.
@@ -1017,4 +1018,3 @@ I aim to review all PRs within 24 hours.
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, the authors have waived all copyright and related or neighboring rights to this work.
-


### PR DESCRIPTION
## What changed

- Adds UIZZE to the existing MCP `Design` section.
- Describes the free skill, MCP access, supported web/iOS reference workflow, design contracts, and finish-gate reviews.
- Uses the official product URL without tracking parameters.

## Why it belongs

UIZZE is directly usable by coding agents during UI implementation, and the entry sits beside the existing Figma MCP design resource rather than creating a promotional category.

## Validation

- Confirmed there was no existing UIZZE entry.
- Confirmed `https://uizze.com` returns HTTP 200.
- Confirmed the README contains exactly one UIZZE entry and no tracking or pricing link.

Disclosure: I am affiliated with UIZZE and am submitting this from the Aislon organization fork.
