### PR TITLE
Add DevProjex to Context Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ The emerging discipline of feeding AI the right context to improve output qualit
 
 - [Repomix](https://github.com/yamadashy/repomix) - Pack your entire repository into a single AI-friendly file for pasting into LLM chats. Smart token management. **[Free]** **[Open Source]**
 - [code2prompt](https://github.com/mufeedvh/code2prompt) - Convert your codebase into an LLM-ready prompt with directory traversal, filtering, and token counting. **[Free]** **[Open Source]**
+- [DevProjex](https://github.com/Avazbek22/DevProjex) - Builds clean, AI-ready project context with folder trees, file contents, token counting, Smart Ignore, preview, and multi-format export through a fast GUI and CLI. **[Free]** **[Open Source]**
 - [Agentic Context](https://github.com/punkpeye/agentic-context) - Tools for structuring and managing context in agentic coding workflows. **[Free]** **[Open Source]**
 - [AI Context Files](https://github.com/nicholasgriffintn/ai-context-files) - Proposed standard for `.context` files that help AI tools understand your project structure and conventions. **[Free]** **[Open Source]**
 - [Files to Prompt](https://github.com/simonw/files-to-prompt) - Simple CLI tool by Simon Willison to concatenate multiple files into a single prompt. **[Free]** **[Open Source]**

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ The emerging discipline of feeding AI the right context to improve output qualit
 
 - [Repomix](https://github.com/yamadashy/repomix) - Pack your entire repository into a single AI-friendly file for pasting into LLM chats. Smart token management. **[Free]** **[Open Source]**
 - [code2prompt](https://github.com/mufeedvh/code2prompt) - Convert your codebase into an LLM-ready prompt with directory traversal, filtering, and token counting. **[Free]** **[Open Source]**
-- [DevProjex](https://github.com/Avazbek22/DevProjex) - Builds clean, AI-ready project context with folder trees, file contents, token counting, Smart Ignore, preview, and multi-format export through a fast GUI and CLI. **[Free]** **[Open Source]**
+- [DevProjex](https://github.com/Avazbek22/DevProjex) - Local-first GUI, TUI, CLI, and read-only MCP workspace for selecting, previewing, redacting, compressing, and packing codebase context for AI assistants and coding agents. **[Free]** **[Open Source]**
 - [Agentic Context](https://github.com/punkpeye/agentic-context) - Tools for structuring and managing context in agentic coding workflows. **[Free]** **[Open Source]**
 - [AI Context Files](https://github.com/nicholasgriffintn/ai-context-files) - Proposed standard for `.context` files that help AI tools understand your project structure and conventions. **[Free]** **[Open Source]**
 - [Files to Prompt](https://github.com/simonw/files-to-prompt) - Simple CLI tool by Simon Willison to concatenate multiple files into a single prompt. **[Free]** **[Open Source]**


### PR DESCRIPTION
Adds DevProjex to Context Engineering as a local-first context workspace for AI coding workflows. It now provides GUI, TUI, CLI, and a built-in read-only MCP server for selecting, previewing, redacting, compressing, and packing codebase context, with MCP-enforced secret redaction, Git scopes, and token budgets.